### PR TITLE
feat: enforce semver for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:base"],
+	"extends": ["config:base", ":semanticCommits"],
 	"postUpdateOptions": ["yarnDedupeHighest"]
 }


### PR DESCRIPTION
Even though the renovate bot should have done this automatically, it did not default to semver commits.