### PR TITLE
fix: change adapter to auto again

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-static';
+import adapter from '@sveltejs/adapter-auto';
 import preprocess from 'svelte-preprocess';
 import { optimizeImports, elements, icons } from 'carbon-preprocess-svelte';
 


### PR DESCRIPTION
CI seems to fail with forcing the svelte adapter to static, might need to revise this later.
