### PR TITLE
fix: remove prerender default

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,11 +9,7 @@ const config = {
 	kit: {
 		adapter: adapter({
 			precompress: true
-		}),
-
-		prerender: {
-			default: true
-		}
+		})
 	}
 };
 


### PR DESCRIPTION
As seen here https://github.com/sveltejs/kit/pull/6197 the prerender option has been removed and compilation on never sveltekit versions would fail.